### PR TITLE
[-] Remove Hotkey Win+C for History Tool due to removal of this default hotkey in Clipjump 11.6.1

### DIFF
--- a/website/docs/basic_help.html
+++ b/website/docs/basic_help.html
@@ -211,7 +211,7 @@ for this function in the Settings Editor.<br>
 
 <a name=export><h2>Export and share Clipboards</h2></a>
 Clipjump supports exporting clipboards as files which can be stored as a record OR send to a friend.<br>
-The feature is accessible by tapping <kbd>E</kbd> in <a href="#pastemd">Paste Mode</a> and by the shortcut <kbd>Ctrl</kbd> + <kbd>E</kbd> in the Clipjump History Tool.<br>
+The feature is accessible by tapping <kbd>E</kbd> in <a href="#pastemd">Paste Mode</a> and by the shortcut <kbd>Ctrl</kbd> + <kbd>E</kbd> in the <a href="history.html">History Tool</a>.<br>
 The  lip or  lipboard when exported will be saved in <em>My Documents</em> with a name export<var>x</var>.cj where <var>x</var> is a variable.<br>
 The .cj file extension when used with <a href=#fdata>Copy File Data</a> directs Clipjump to load the file contents into itself.
 <br><br /><br>

--- a/website/docs/shortcuts.html
+++ b/website/docs/shortcuts.html
@@ -31,10 +31,6 @@
 		<td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd></td>
 		<td><a href=#actmd>Action Mode</a></td>
 	</tr>
-	<tr>
-		<td><kbd>Win</kbd> + <kbd>C</kbd></td>
-		<td><a href=history.html>Clipboard History Tool</a></td>
-	</tr>
 </table>
 
 
@@ -114,7 +110,7 @@ So, pressing <kbd>X</kbd> while holding <kbd>Ctrl</kbd> in [Delete All Mode] wil
 <kbd>F</kbd> - <a href=basic_help.html#fdata>Copy File Data</a>
 <kbd>F1</kbd> - Help
 <kbd>F2</kbd> - <a href=#pstmd>Paste Mode Shortcuts</a>
-<kbd>H</kbd> - <a href=history.html>Clipboard history</a>
+<kbd>H</kbd> - <a href=history.html>Clipboard History</a>
 <kbd>L</kbd> - <a href=basic_help.html#ignorew>Ignore Windows Manager</a>
 <kbd>M</kbd> - Plugin Manager
 <kbd>0</kbd> - <a href=organizer.html>Channel Organizer</a>


### PR DESCRIPTION
Removing default hotkey Win+C  for History Tool from Clipjump 11.6.1 should be transferred to complete documentation